### PR TITLE
Update Ruby 2.7.5

### DIFF
--- a/units-in-ruby.gemspec
+++ b/units-in-ruby.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = "units-in-ruby"
-  s.version     = '0.0.2'
+  s.version     = '0.0.3'
   s.authors     = ["Brandon Fosdick", "Meseker Yohannes"]
   s.email       = ["bfoz@bfoz.net"]
   s.homepage    = 'http://github.com/bfoz/units-ruby'
@@ -16,5 +16,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.add_dependency "cmath"
   s.add_development_dependency "minitest"
 end


### PR DESCRIPTION
Starting with Ruby 2.7, the CMath library has been removed from the stdlibs.
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/

It is now a gem: https://github.com/ruby/cmath